### PR TITLE
✨ feat: 결제 수단 초기 데이터 설정 추가 및 수단 조회 api 수정

### DIFF
--- a/src/main/java/com/nhnacademy/payment_server/config/InitDataConfig.java
+++ b/src/main/java/com/nhnacademy/payment_server/config/InitDataConfig.java
@@ -16,7 +16,7 @@ public class InitDataConfig {
     public CommandLineRunner initPaymentMethods(PaymentMethodRepository repository) {
         return args -> {
             List<PaymentMethod> methods = List.of(
-                    PaymentMethod.builder().name("TOSS").alias("간편결제/신용카드").isActive(true).build(),
+                    PaymentMethod.builder().name("TOSS").alias("간편결제 / 신용카드").isActive(true).build(),
                     PaymentMethod.builder().name("BANK_TRANSFER").alias("계좌이체").isActive(false).build(),
                     PaymentMethod.builder().name("VIRTUAL_ACCOUNT").alias("가상계좌").isActive(false).build()
             );

--- a/src/main/java/com/nhnacademy/payment_server/config/InitDataConfig.java
+++ b/src/main/java/com/nhnacademy/payment_server/config/InitDataConfig.java
@@ -3,29 +3,49 @@ package com.nhnacademy.payment_server.config;
 import com.nhnacademy.payment_server.entity.PaymentMethod;
 import com.nhnacademy.payment_server.repository.PaymentMethodRepository;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.transaction.annotation.Transactional;
 
 @Configuration
 @Profile("!test")
+@RequiredArgsConstructor
 public class InitDataConfig {
 
-    @Bean
-    public CommandLineRunner initPaymentMethods(PaymentMethodRepository repository) {
-        return args -> {
-            List<PaymentMethod> methods = List.of(
-                    PaymentMethod.builder().name("TOSS").alias("간편결제 / 신용카드").isActive(true).build(),
-                    PaymentMethod.builder().name("BANK_TRANSFER").alias("계좌이체").isActive(false).build(),
-                    PaymentMethod.builder().name("VIRTUAL_ACCOUNT").alias("가상계좌").isActive(false).build()
-            );
+    private final PaymentMethodRepository repository;
 
-            for (PaymentMethod method : methods) {
-                if (!repository.existsByName(method.getName())) {
-                    repository.save(method);
-                }
-            }
-        };
+    @Bean
+    public CommandLineRunner initPaymentMethods() {
+        return args -> initializeMethods();
+    }
+
+    @Transactional
+    public void initializeMethods() {
+        List<PaymentMethod> targetMethods = List.of(
+                PaymentMethod.builder().name("Toss").alias("간편결제/신용카드").isActive(true).build(),
+                PaymentMethod.builder().name("TRANSFER").alias("계좌이체").isActive(false).build(),
+                PaymentMethod.builder().name("VIRTUAL_ACCOUNT").alias("무통장입금").isActive(false).build()
+        );
+
+        // N+1 문제 해결
+        // DB에 있는 모든 이름을 한 번에 가져와서 Set
+        Set<String> existingNames = repository.findAll().stream()
+                .map(PaymentMethod::getName)
+                .collect(Collectors.toSet());
+
+        // 메모리 상에서 비교 후 없는 것만 필터링
+        List<PaymentMethod> newMethods = targetMethods.stream()
+                .filter(m -> !existingNames.contains(m.getName()))
+                .toList();
+
+        // 한 번에 저장
+        if (!newMethods.isEmpty()) {
+            repository.saveAll(newMethods);
+        }
     }
 }

--- a/src/main/java/com/nhnacademy/payment_server/config/InitDataConfig.java
+++ b/src/main/java/com/nhnacademy/payment_server/config/InitDataConfig.java
@@ -1,0 +1,31 @@
+package com.nhnacademy.payment_server.config;
+
+import com.nhnacademy.payment_server.entity.PaymentMethod;
+import com.nhnacademy.payment_server.repository.PaymentMethodRepository;
+import java.util.List;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("!test")
+public class InitDataConfig {
+
+    @Bean
+    public CommandLineRunner initPaymentMethods(PaymentMethodRepository repository) {
+        return args -> {
+            List<PaymentMethod> methods = List.of(
+                    PaymentMethod.builder().name("TOSS").alias("간편결제/신용카드").isActive(true).build(),
+                    PaymentMethod.builder().name("BANK_TRANSFER").alias("계좌이체").isActive(false).build(),
+                    PaymentMethod.builder().name("VIRTUAL_ACCOUNT").alias("가상계좌").isActive(false).build()
+            );
+
+            for (PaymentMethod method : methods) {
+                if (!repository.existsByName(method.getName())) {
+                    repository.save(method);
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/com/nhnacademy/payment_server/controller/PaymentMethodController.java
+++ b/src/main/java/com/nhnacademy/payment_server/controller/PaymentMethodController.java
@@ -22,11 +22,6 @@ public class PaymentMethodController implements PaymentMethodSwagger {
     private final PaymentMethodService paymentMethodService;
 
     @GetMapping
-    public ResponseEntity<List<PaymentMethodResponse>> getActiveMethods() {
-        return ResponseEntity.ok(paymentMethodService.getActiveMethods());
-    }
-
-    @GetMapping("/admin")
     public ResponseEntity<List<PaymentMethodResponse>> getAllMethods() {
         return ResponseEntity.ok(paymentMethodService.getAllMethods());
     }

--- a/src/main/java/com/nhnacademy/payment_server/docs/PaymentMethodSwagger.java
+++ b/src/main/java/com/nhnacademy/payment_server/docs/PaymentMethodSwagger.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "PaymentMethod API", description = "결제 수단 관련 API")
 public interface PaymentMethodSwagger {
 
-    @Operation(summary = "전체 결제 수단 조회", description = "모든 결제 수단을 조회합니다.")
+    @Operation(summary = "전체 결제 수단 조회", description = "모든 결제 수단을 조회합니다. (프론트에서 isActive 필드로 UI 구분)")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공 (전체 결제수단 리스트 반환)"),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류")

--- a/src/main/java/com/nhnacademy/payment_server/docs/PaymentMethodSwagger.java
+++ b/src/main/java/com/nhnacademy/payment_server/docs/PaymentMethodSwagger.java
@@ -15,16 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "PaymentMethod API", description = "결제 수단 관련 API")
 public interface PaymentMethodSwagger {
 
-    @Operation(summary = "사용 가능한 결제 수단 조회", description = "주문 결제 페이지에서 사용자에게 보여줄 활성화된 결제 수단 목록을 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공 (활성화된 결제수단 리스트 반환)"),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
-    })
-    ResponseEntity<List<PaymentMethodResponse>> getActiveMethods();
-
-
-    // 2. 관리자용 (전체 조회)
-    @Operation(summary = "[관리자] 전체 결제 수단 조회", description = "관리자 설정을 위해 활성/비활성 여부와 관계없이 모든 결제 수단을 조회합니다.")
+    @Operation(summary = "전체 결제 수단 조회", description = "모든 결제 수단을 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공 (전체 결제수단 리스트 반환)"),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류")
@@ -32,8 +23,7 @@ public interface PaymentMethodSwagger {
     ResponseEntity<List<PaymentMethodResponse>> getAllMethods();
 
 
-    // 3. 관리자용 (상태 변경)
-    @Operation(summary = "[관리자] 결제 수단 활성/비활성 토글", description = "특정 결제 수단의 사용 가능 여부를 변경합니다.")
+    @Operation(summary = "[관리자] 결제 수단 활성/비활성 토글", description = "결제 수단의 사용 가능 여부를 변경합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "상태 변경 성공"),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 결제 수단 ID"),

--- a/src/main/java/com/nhnacademy/payment_server/entity/PaymentMethod.java
+++ b/src/main/java/com/nhnacademy/payment_server/entity/PaymentMethod.java
@@ -21,7 +21,7 @@ public class PaymentMethod {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, length = 100, unique = true)
     private String name;
 
     @Column(nullable = false)

--- a/src/main/java/com/nhnacademy/payment_server/repository/PaymentMethodRepository.java
+++ b/src/main/java/com/nhnacademy/payment_server/repository/PaymentMethodRepository.java
@@ -1,11 +1,10 @@
 package com.nhnacademy.payment_server.repository;
 
 import com.nhnacademy.payment_server.entity.PaymentMethod;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentMethodRepository extends JpaRepository<PaymentMethod, Long> {
     Optional<PaymentMethod> findByName(String name);
-    List<PaymentMethod> findByIsActiveTrue();
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/nhnacademy/payment_server/service/PaymentMethodService.java
+++ b/src/main/java/com/nhnacademy/payment_server/service/PaymentMethodService.java
@@ -4,7 +4,6 @@ import com.nhnacademy.payment_server.dto.response.PaymentMethodResponse;
 import java.util.List;
 
 public interface PaymentMethodService {
-    List<PaymentMethodResponse> getActiveMethods();
     List<PaymentMethodResponse> getAllMethods();
     void updateStatus(Long methodId, boolean isActive);
 }

--- a/src/main/java/com/nhnacademy/payment_server/service/impl/PaymentMethodServiceImpl.java
+++ b/src/main/java/com/nhnacademy/payment_server/service/impl/PaymentMethodServiceImpl.java
@@ -19,13 +19,6 @@ public class PaymentMethodServiceImpl implements PaymentMethodService {
     private final PaymentMethodRepository paymentMethodRepository;
 
     @Override
-    public List<PaymentMethodResponse> getActiveMethods() {
-        return paymentMethodRepository.findByIsActiveTrue().stream()
-                .map(PaymentMethodResponse::from)
-                .toList();
-    }
-
-    @Override
     public List<PaymentMethodResponse> getAllMethods() {
         return paymentMethodRepository.findAll().stream()
                 .map(PaymentMethodResponse::from)

--- a/src/test/java/com/nhnacademy/payment_server/config/InitDataConfigTest.java
+++ b/src/test/java/com/nhnacademy/payment_server/config/InitDataConfigTest.java
@@ -1,0 +1,64 @@
+package com.nhnacademy.payment_server.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.nhnacademy.payment_server.entity.PaymentMethod;
+import com.nhnacademy.payment_server.repository.PaymentMethodRepository;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.CommandLineRunner;
+
+@ExtendWith(MockitoExtension.class)
+class InitDataConfigTest {
+
+    @Mock
+    private PaymentMethodRepository repository;
+
+    @InjectMocks
+    private InitDataConfig initDataConfig;
+
+    @Test
+    @DisplayName("DB에 데이터가 없으면 3개 모두 저장 (Branch: True)")
+    void initPaymentMethods_saveAll() throws Exception {
+        given(repository.findAll()).willReturn(Collections.emptyList());
+
+        CommandLineRunner runner = initDataConfig.initPaymentMethods();
+        runner.run();
+
+        ArgumentCaptor<List<PaymentMethod>> captor = ArgumentCaptor.forClass(List.class);
+        verify(repository).saveAll(captor.capture());
+
+        List<PaymentMethod> savedMethods = captor.getValue();
+        assertThat(savedMethods).hasSize(3);
+        assertThat(savedMethods)
+                .extracting(PaymentMethod::getName)
+                .containsExactlyInAnyOrder("Toss", "TRANSFER", "VIRTUAL_ACCOUNT");
+    }
+
+    @Test
+    @DisplayName("DB에 이미 데이터가 있으면 저장x (Branch: False)")
+    void initPaymentMethods_skipSave() throws Exception {
+        List<PaymentMethod> existingMethods = List.of(
+                PaymentMethod.builder().name("Toss").alias("간편결제/신용카드").isActive(true).build(),
+                PaymentMethod.builder().name("TRANSFER").alias("계좌이체").isActive(false).build(),
+                PaymentMethod.builder().name("VIRTUAL_ACCOUNT").alias("무통장입금").isActive(false).build()
+        );
+        given(repository.findAll()).willReturn(existingMethods);
+
+        CommandLineRunner runner = initDataConfig.initPaymentMethods();
+        runner.run();
+
+        verify(repository, never()).saveAll(anyList());
+    }
+}

--- a/src/test/java/com/nhnacademy/payment_server/controller/PaymentMethodControllerTest.java
+++ b/src/test/java/com/nhnacademy/payment_server/controller/PaymentMethodControllerTest.java
@@ -33,13 +33,13 @@ class PaymentMethodControllerTest {
     private PaymentMethodService paymentMethodService;
 
     @Test
-    @DisplayName("사용자: 활성화된 결제 수단 조회 성공")
+    @DisplayName("결제 수단 조회 성공")
     void getActiveMethods_Success() throws Exception {
         // given
         PaymentMethodResponse toss = new PaymentMethodResponse(1L, "TOSS", "토스", true);
         PaymentMethodResponse point = new PaymentMethodResponse(2L, "POINT", "포인트", true);
 
-        given(paymentMethodService.getActiveMethods()).willReturn(List.of(toss, point));
+        given(paymentMethodService.getAllMethods()).willReturn(List.of(toss, point));
 
         // when & then
         mockMvc.perform(get("/api/payments/methods")

--- a/src/test/java/com/nhnacademy/payment_server/service/PaymentMethodServiceTest.java
+++ b/src/test/java/com/nhnacademy/payment_server/service/PaymentMethodServiceTest.java
@@ -28,19 +28,6 @@ public class PaymentMethodServiceTest {
     PaymentMethodServiceImpl paymentMethodService;
 
     @Test
-    @DisplayName("활성화된 결제수단 조회 성공")
-    void getActiveMethods_success() {
-        PaymentMethod m1 = PaymentMethod.builder().name("TOSS").isActive(true).build();
-        ReflectionTestUtils.setField(m1, "id", 1L);
-        when(paymentMethodRepository.findByIsActiveTrue()).thenReturn(List.of(m1));
-
-        List<PaymentMethodResponse> list = paymentMethodService.getActiveMethods();
-
-        assertThat(list).hasSize(1);
-        assertThat(list.getFirst().getName()).isEqualTo("TOSS");
-    }
-
-    @Test
     @DisplayName("모든 결제수단 조회 성공")
     void getAllMethods_success() {
         PaymentMethod m1 = PaymentMethod.builder().name("TOSS").isActive(true).build();


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #8

## 📝작업 내용

> 기존 data.sql로 삽입하던 결제수단을 서버가 실행될때 결제수단이 없다면 생성되게 바꾸엇고 기존 활성화된 결제수단만 볼수있던 api가 필요 없어져서 전체 조회수단을 기본적으로 사용하게끔 바꾸었습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 애플리케이션 시작 시 기본 결제 수단(토스, 계좌이체, 가상계좌)이 자동으로 등록됩니다.

* **개선**
  * 결제 수단 조회 API가 통합되어 모든 결제 수단을 반환하도록 변경되었습니다.
  * 결제 수단 이름에 중복 방지(유일 제약)가 적용되었습니다.

* **테스트**
  * 초기 데이터 등록 동작을 검증하는 단위 테스트가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->