### PR TITLE
✨ feat: 에러코드, 방어코드 추가 및 feign 에러시 재시도 안하게 수정

### DIFF
--- a/src/main/java/com/nhnacademy/payment_server/config/FeignConfig.java
+++ b/src/main/java/com/nhnacademy/payment_server/config/FeignConfig.java
@@ -1,0 +1,14 @@
+package com.nhnacademy.payment_server.config;
+
+import feign.Retryer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeignConfig {
+
+    @Bean
+    public Retryer retryer() {
+        return Retryer.NEVER_RETRY; // feign 호출 실패시 기본 5회 재시도에서 즉시 실패하게 바꿈
+    }
+}

--- a/src/main/java/com/nhnacademy/payment_server/config/InitDataConfig.java
+++ b/src/main/java/com/nhnacademy/payment_server/config/InitDataConfig.java
@@ -1,51 +1,21 @@
 package com.nhnacademy.payment_server.config;
 
-import com.nhnacademy.payment_server.entity.PaymentMethod;
-import com.nhnacademy.payment_server.repository.PaymentMethodRepository;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import com.nhnacademy.payment_server.service.PaymentMethodInitService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.transaction.annotation.Transactional;
 
 @Configuration
 @Profile("!test")
 @RequiredArgsConstructor
 public class InitDataConfig {
 
-    private final PaymentMethodRepository repository;
+    private final PaymentMethodInitService initService;
 
     @Bean
     public CommandLineRunner initPaymentMethods() {
-        return args -> initializeMethods();
-    }
-
-    @Transactional
-    public void initializeMethods() {
-        List<PaymentMethod> targetMethods = List.of(
-                PaymentMethod.builder().name("Toss").alias("간편결제/신용카드").isActive(true).build(),
-                PaymentMethod.builder().name("TRANSFER").alias("계좌이체").isActive(false).build(),
-                PaymentMethod.builder().name("VIRTUAL_ACCOUNT").alias("무통장입금").isActive(false).build()
-        );
-
-        // N+1 문제 해결
-        // DB에 있는 모든 이름을 한 번에 가져와서 Set
-        Set<String> existingNames = repository.findAll().stream()
-                .map(PaymentMethod::getName)
-                .collect(Collectors.toSet());
-
-        // 메모리 상에서 비교 후 없는 것만 필터링
-        List<PaymentMethod> newMethods = targetMethods.stream()
-                .filter(m -> !existingNames.contains(m.getName()))
-                .toList();
-
-        // 한 번에 저장
-        if (!newMethods.isEmpty()) {
-            repository.saveAll(newMethods);
-        }
+        return args -> initService.initializeMethods(); // 프록시 적용
     }
 }

--- a/src/main/java/com/nhnacademy/payment_server/exception/ErrorCode.java
+++ b/src/main/java/com/nhnacademy/payment_server/exception/ErrorCode.java
@@ -21,9 +21,9 @@ public enum ErrorCode {
     NOT_IMPLEMENTED(HttpStatus.NOT_IMPLEMENTED, "P007", "추후 구현 예정인 결제 수단입니다."),
 
     // 404 NOT_FOUND
-    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "P006", "존재하지 않는 결제 정보입니다."),
-    METHOD_NOT_FOUND(HttpStatus.NOT_FOUND, "P007", "존재하지 않는 결제 수단입니다."),
-    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "P008", "존재하지 않는 주문 정보입니다."),
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "P008", "존재하지 않는 결제 정보입니다."),
+    METHOD_NOT_FOUND(HttpStatus.NOT_FOUND, "P009", "존재하지 않는 결제 수단입니다."),
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "P010", "존재하지 않는 주문 정보입니다."),
 
     // 500 INTERNAL_SERVER_ERROR
     TOSS_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "P500", "토스 페이먼츠 처리 중 오류가 발생했습니다."),

--- a/src/main/java/com/nhnacademy/payment_server/exception/ErrorCode.java
+++ b/src/main/java/com/nhnacademy/payment_server/exception/ErrorCode.java
@@ -13,17 +13,24 @@ public enum ErrorCode {
     INVALID_AMOUNT(HttpStatus.BAD_REQUEST, "P002", "결제 금액이 일치하지 않습니다."),
     INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "P003", "처리할 수 없는 결제 상태입니다."),
     ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "P004", "이미 취소된 결제입니다."),
+    // 기능 없고 지원 예정도 아님
     UNSUPPORTED_METHOD(HttpStatus.BAD_REQUEST, "P005", "지원하지 않는 결제 수단입니다."),
+    // 기능은 있는데 점검 중
+    METHOD_DISABLED(HttpStatus.BAD_REQUEST, "P006", "현재 사용할 수 없는 결제 수단입니다."),
+    // 기능 없고 지원 예정
+    NOT_IMPLEMENTED(HttpStatus.NOT_IMPLEMENTED, "P007", "추후 구현 예정인 결제 수단입니다."),
 
     // 404 NOT_FOUND
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "P006", "존재하지 않는 결제 정보입니다."),
     METHOD_NOT_FOUND(HttpStatus.NOT_FOUND, "P007", "존재하지 않는 결제 수단입니다."),
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "P008", "존재하지 않는 주문 정보입니다."),
 
     // 500 INTERNAL_SERVER_ERROR
     TOSS_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "P500", "토스 페이먼츠 처리 중 오류가 발생했습니다."),
     POINT_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "P501", "포인트 처리 중 오류가 발생했습니다."),
 
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C001", "서버 내부 오류가 발생했습니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C001", "서버 내부 오류가 발생했습니다."),
+    ORDER_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C002", "주문 서버 내부 오류가 발생했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/nhnacademy/payment_server/service/PaymentMethodInitService.java
+++ b/src/main/java/com/nhnacademy/payment_server/service/PaymentMethodInitService.java
@@ -1,0 +1,42 @@
+package com.nhnacademy.payment_server.service;
+
+import com.nhnacademy.payment_server.entity.PaymentMethod;
+import com.nhnacademy.payment_server.repository.PaymentMethodRepository;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentMethodInitService {
+
+    private final PaymentMethodRepository repository;
+
+    @Transactional
+    public void initializeMethods() {
+        List<PaymentMethod> targetMethods = List.of(
+                PaymentMethod.builder().name("Toss").alias("간편결제 / 카드결제").isActive(true).build(),
+                PaymentMethod.builder().name("TRANSFER").alias("계좌이체").isActive(false).build(),
+                PaymentMethod.builder().name("VIRTUAL_ACCOUNT").alias("무통장입금").isActive(false).build()
+        );
+
+        // N+1 문제 해결
+        // DB에 있는 모든 이름을 한 번에 가져와서 Set
+        Set<String> existingNames = repository.findAll().stream()
+                .map(PaymentMethod::getName)
+                .collect(Collectors.toSet());
+
+        // 메모리 상에서 비교 후 없는 것만 필터링
+        List<PaymentMethod> newMethods = targetMethods.stream()
+                .filter(m -> !existingNames.contains(m.getName()))
+                .toList();
+
+        // 한 번에 저장
+        if (!newMethods.isEmpty()) {
+            repository.saveAll(newMethods);
+        }
+    }
+}

--- a/src/main/java/com/nhnacademy/payment_server/service/PaymentMethodInitService.java
+++ b/src/main/java/com/nhnacademy/payment_server/service/PaymentMethodInitService.java
@@ -18,7 +18,7 @@ public class PaymentMethodInitService {
     @Transactional
     public void initializeMethods() {
         List<PaymentMethod> targetMethods = List.of(
-                PaymentMethod.builder().name("Toss").alias("간편결제 / 카드결제").isActive(true).build(),
+                PaymentMethod.builder().name("TOSS").alias("간편결제 / 카드결제").isActive(true).build(),
                 PaymentMethod.builder().name("TRANSFER").alias("계좌이체").isActive(false).build(),
                 PaymentMethod.builder().name("VIRTUAL_ACCOUNT").alias("무통장입금").isActive(false).build()
         );

--- a/src/main/java/com/nhnacademy/payment_server/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/nhnacademy/payment_server/service/impl/PaymentServiceImpl.java
@@ -59,13 +59,13 @@ public class PaymentServiceImpl implements PaymentService {
         String provider = requestDto.getPaymentMethod().toUpperCase();
 
         return switch (provider) {
-            case "TOSS" -> processTossPayment(requestDto);
+            case "TOSS" -> processTossPayment(requestDto, paymentMethod);
             case "TRANSFER", "VIRTUAL_ACCOUNT" -> throw new BusinessException(ErrorCode.NOT_IMPLEMENTED);
             default -> throw new BusinessException(ErrorCode.UNSUPPORTED_METHOD);
         };
     }
 
-    public PaymentConfirmResponse processTossPayment(PaymentConfirmRequest requestDto) {
+    public PaymentConfirmResponse processTossPayment(PaymentConfirmRequest requestDto, PaymentMethod paymentMethod) {
         log.info("결제 승인 요청 진입 orderKey: {}, amount: {}", requestDto.getOrderKey(), requestDto.getAmount());
 
         // 검증을 위한 주문 서버 결제 정보
@@ -120,9 +120,6 @@ public class PaymentServiceImpl implements PaymentService {
         }
 
         // 결제 정보 DB 저장
-        PaymentMethod paymentMethod = paymentMethodRepository.findByName("TOSS")
-                .orElseThrow(() -> new BusinessException(ErrorCode.METHOD_NOT_FOUND));
-
         Payment payment = Payment.builder()
                 .paymentMethod(paymentMethod)
                 .orderId(orderId)

--- a/src/main/java/com/nhnacademy/payment_server/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/nhnacademy/payment_server/service/impl/PaymentServiceImpl.java
@@ -24,6 +24,7 @@ import com.nhnacademy.payment_server.repository.PaymentMethodRepository;
 import com.nhnacademy.payment_server.repository.PaymentRepository;
 import com.nhnacademy.payment_server.service.PaymentOutboxService;
 import com.nhnacademy.payment_server.service.PaymentService;
+import feign.FeignException;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -46,12 +47,21 @@ public class PaymentServiceImpl implements PaymentService {
 
     @Override
     public PaymentConfirmResponse confirmPayment(PaymentConfirmRequest requestDto) {
+        // DB에서 결제 수단 조회
+        PaymentMethod paymentMethod = paymentMethodRepository.findByName(requestDto.getPaymentMethod())
+                .orElseThrow(() -> new BusinessException(ErrorCode.METHOD_NOT_FOUND));
+
+        // 관리자가 꺼둔 결제 수단을 선택 했을시
+        if (!paymentMethod.isActive()) {
+            throw new BusinessException(ErrorCode.METHOD_DISABLED);
+        }
+
         String provider = requestDto.getPaymentMethod().toUpperCase();
 
         return switch (provider) {
             case "TOSS" -> processTossPayment(requestDto);
-            case "POINT" -> throw new BusinessException(ErrorCode.UNSUPPORTED_METHOD);
-            default -> throw new BusinessException(ErrorCode.METHOD_NOT_FOUND);
+            case "TRANSFER", "VIRTUAL_ACCOUNT" -> throw new BusinessException(ErrorCode.NOT_IMPLEMENTED);
+            default -> throw new BusinessException(ErrorCode.UNSUPPORTED_METHOD);
         };
     }
 
@@ -60,7 +70,17 @@ public class PaymentServiceImpl implements PaymentService {
 
         // 검증을 위한 주문 서버 결제 정보
         String orderKey = requestDto.getOrderKey();
-        OrderValidationInfoResponse orderDto = orderClient.getOrderByKey(orderKey);
+        OrderValidationInfoResponse orderDto;
+
+        try {
+            orderDto = orderClient.getOrderByKey(orderKey);
+        } catch (FeignException.NotFound e) {
+            log.error("주문 정보를 찾을 수 없음: {}", orderKey);
+            throw new BusinessException(ErrorCode.ORDER_NOT_FOUND);
+        } catch (FeignException e) {
+            log.error("주문 서버 통신 오류: {}", orderKey, e);
+            throw new BusinessException(ErrorCode.ORDER_SERVER_ERROR);
+        }
 
         Long orderId = orderDto.getOrderId();
         Long memberId = orderDto.getUserId();

--- a/src/test/java/com/nhnacademy/payment_server/config/InitDataConfigTest.java
+++ b/src/test/java/com/nhnacademy/payment_server/config/InitDataConfigTest.java
@@ -42,14 +42,14 @@ class InitDataConfigTest {
         assertThat(savedMethods).hasSize(3);
         assertThat(savedMethods)
                 .extracting(PaymentMethod::getName)
-                .containsExactlyInAnyOrder("Toss", "TRANSFER", "VIRTUAL_ACCOUNT");
+                .containsExactlyInAnyOrder("TOSS", "TRANSFER", "VIRTUAL_ACCOUNT");
     }
 
     @Test
     @DisplayName("DB에 이미 데이터가 있으면 저장x (Branch: False)")
     void initializeMethods_skipSave() {
         List<PaymentMethod> existingMethods = List.of(
-                PaymentMethod.builder().name("Toss").alias("간편결제 / 카드결제").isActive(true).build(),
+                PaymentMethod.builder().name("TOSS").alias("간편결제 / 카드결제").isActive(true).build(),
                 PaymentMethod.builder().name("TRANSFER").alias("계좌이체").isActive(false).build(),
                 PaymentMethod.builder().name("VIRTUAL_ACCOUNT").alias("무통장입금").isActive(false).build()
         );

--- a/src/test/java/com/nhnacademy/payment_server/config/InitDataConfigTest.java
+++ b/src/test/java/com/nhnacademy/payment_server/config/InitDataConfigTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 
 import com.nhnacademy.payment_server.entity.PaymentMethod;
 import com.nhnacademy.payment_server.repository.PaymentMethodRepository;
+import com.nhnacademy.payment_server.service.PaymentMethodInitService;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -17,7 +18,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.CommandLineRunner;
 
 @ExtendWith(MockitoExtension.class)
 class InitDataConfigTest {
@@ -26,15 +26,14 @@ class InitDataConfigTest {
     private PaymentMethodRepository repository;
 
     @InjectMocks
-    private InitDataConfig initDataConfig;
+    private PaymentMethodInitService initService;
 
     @Test
     @DisplayName("DB에 데이터가 없으면 3개 모두 저장 (Branch: True)")
-    void initPaymentMethods_saveAll() throws Exception {
+    void initializeMethods_saveAll() {
         given(repository.findAll()).willReturn(Collections.emptyList());
 
-        CommandLineRunner runner = initDataConfig.initPaymentMethods();
-        runner.run();
+        initService.initializeMethods(); // 서비스 메서드 직접 호출
 
         ArgumentCaptor<List<PaymentMethod>> captor = ArgumentCaptor.forClass(List.class);
         verify(repository).saveAll(captor.capture());
@@ -48,16 +47,15 @@ class InitDataConfigTest {
 
     @Test
     @DisplayName("DB에 이미 데이터가 있으면 저장x (Branch: False)")
-    void initPaymentMethods_skipSave() throws Exception {
+    void initializeMethods_skipSave() {
         List<PaymentMethod> existingMethods = List.of(
-                PaymentMethod.builder().name("Toss").alias("간편결제/신용카드").isActive(true).build(),
+                PaymentMethod.builder().name("Toss").alias("간편결제 / 카드결제").isActive(true).build(),
                 PaymentMethod.builder().name("TRANSFER").alias("계좌이체").isActive(false).build(),
                 PaymentMethod.builder().name("VIRTUAL_ACCOUNT").alias("무통장입금").isActive(false).build()
         );
         given(repository.findAll()).willReturn(existingMethods);
 
-        CommandLineRunner runner = initDataConfig.initPaymentMethods();
-        runner.run();
+        initService.initializeMethods();
 
         verify(repository, never()).saveAll(anyList());
     }

--- a/src/test/java/com/nhnacademy/payment_server/service/PaymentServiceTest.java
+++ b/src/test/java/com/nhnacademy/payment_server/service/PaymentServiceTest.java
@@ -127,6 +127,9 @@ public class PaymentServiceTest {
         // given
         PaymentConfirmRequest request = new PaymentConfirmRequest("testKey", "apple", 10000L, "TOSS");
 
+        PaymentMethod mockMethod = PaymentMethod.builder().name("TOSS").isActive(true).build();
+        given(paymentMethodRepository.findByName("TOSS")).willReturn(Optional.of(mockMethod));
+
         OrderValidationInfoResponse orderDto = OrderValidationInfoResponse.builder()
                 .orderId(100L)
                 .orderKey("apple")
@@ -151,6 +154,9 @@ public class PaymentServiceTest {
     void confirmPayment_Fail_AmountMismatch() {
         String tossOrderId = "hack_order";
         PaymentConfirmRequest request = new PaymentConfirmRequest("key", tossOrderId, 100L, "TOSS"); // 100원 요청
+
+        PaymentMethod mockMethod = PaymentMethod.builder().name("TOSS").isActive(true).build();
+        given(paymentMethodRepository.findByName("TOSS")).willReturn(Optional.of(mockMethod));
 
         OrderValidationInfoResponse orderDto = OrderValidationInfoResponse.builder()
                 .paymentAmount(50000L)
@@ -244,13 +250,16 @@ public class PaymentServiceTest {
     }
 
     @Test
-    @DisplayName("결제 실패: 아직 지원 안 하는 POINT 결제")
+    @DisplayName("결제 실패: 아직 지원 안 하는 TRANSFER 결제")
     void confirmPayment_Fail_PointMethod() {
-        PaymentConfirmRequest request = new PaymentConfirmRequest("key", "order", 100L, "POINT");
+        PaymentConfirmRequest request = new PaymentConfirmRequest("key", "order", 100L, "TRANSFER");
+
+        PaymentMethod mockMethod = PaymentMethod.builder().name("TRANSFER").isActive(true).build();
+        given(paymentMethodRepository.findByName("TRANSFER")).willReturn(Optional.of(mockMethod));
 
         assertThatThrownBy(() -> paymentService.confirmPayment(request))
                 .isInstanceOf(BusinessException.class)
-                .extracting("errorCode").isEqualTo(ErrorCode.UNSUPPORTED_METHOD);
+                .extracting("errorCode").isEqualTo(ErrorCode.NOT_IMPLEMENTED);
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

#15

## 📝작업 내용

> 에러코드, 방어코드 추가 및 feign 에러시 재시도 안하게 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 결제 수단 초기화 로직을 서비스로 분리하여 안전하고 일관된 초기화 지원
  * 외부 호출 재시도 비활성화(실패 시 즉시 실패 처리)

* **버그 수정 / 개선**
  * 결제 수단 활성화 상태 검증 강화 및 관련 오류 코드 추가(METHOD_DISABLED, NOT_IMPLEMENTED 등)
  * 주문 조회 오류 분류 개선(존재하지 않는 주문, 서버 내부 오류 등)

* **테스트**
  * 결제 흐름 및 초기화 동작 관련 단위테스트 보강 및 기대값 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->