### PR TITLE
✨ feat: 관리자 매출 통계 API 구현 [#13]

### DIFF
--- a/src/main/java/com/nhnacademy/payment_server/controller/AdminPaymentController.java
+++ b/src/main/java/com/nhnacademy/payment_server/controller/AdminPaymentController.java
@@ -1,0 +1,39 @@
+package com.nhnacademy.payment_server.controller;
+
+import com.nhnacademy.payment_server.docs.AdminPaymentSwagger;
+import com.nhnacademy.payment_server.dto.response.DailySalesResponse;
+import com.nhnacademy.payment_server.dto.response.PaymentStatsResponse;
+import com.nhnacademy.payment_server.service.PaymentStatService;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/payments/admin/stats")
+@RequiredArgsConstructor
+public class AdminPaymentController implements AdminPaymentSwagger {
+
+    private final PaymentStatService paymentStatService;
+
+    @GetMapping("/summary")
+    @Override
+    public ResponseEntity<PaymentStatsResponse> getSummary() {
+        return ResponseEntity.ok(paymentStatService.getTotalStats());
+    }
+
+    @GetMapping("/daily")
+    @Override
+    public ResponseEntity<List<DailySalesResponse>> getDailyStats(LocalDate startDate, LocalDate endDate) {
+        // 날짜 파라미터 없으면 최근 7일
+        if (endDate == null) endDate = LocalDate.now();
+        if (startDate == null) startDate = endDate.minusDays(7);
+
+        return ResponseEntity.ok(
+                paymentStatService.getDailyStats(startDate.atStartOfDay(), endDate.atTime(23, 59, 59))
+        );
+    }
+}

--- a/src/main/java/com/nhnacademy/payment_server/controller/AdminPaymentController.java
+++ b/src/main/java/com/nhnacademy/payment_server/controller/AdminPaymentController.java
@@ -3,13 +3,18 @@ package com.nhnacademy.payment_server.controller;
 import com.nhnacademy.payment_server.docs.AdminPaymentSwagger;
 import com.nhnacademy.payment_server.dto.response.DailySalesResponse;
 import com.nhnacademy.payment_server.dto.response.PaymentStatsResponse;
+import com.nhnacademy.payment_server.exception.BusinessException;
+import com.nhnacademy.payment_server.exception.ErrorCode;
 import com.nhnacademy.payment_server.service.PaymentStatService;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -27,13 +32,26 @@ public class AdminPaymentController implements AdminPaymentSwagger {
 
     @GetMapping("/daily")
     @Override
-    public ResponseEntity<List<DailySalesResponse>> getDailyStats(LocalDate startDate, LocalDate endDate) {
-        // 날짜 파라미터 없으면 최근 7일
-        if (endDate == null) endDate = LocalDate.now();
-        if (startDate == null) startDate = endDate.minusDays(7);
+    public ResponseEntity<List<DailySalesResponse>> getDailyStats(
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+
+        if (endDate == null) {
+            endDate = LocalDate.now();
+        }
+
+        if (startDate == null) {
+            startDate = endDate.minusDays(6);  // 날짜 파라미터 없으면 최근 7일
+        }
+
+        if (startDate.isAfter(endDate)) {
+            throw new BusinessException(ErrorCode.INVALID_DATE_RANGE);
+        }
 
         return ResponseEntity.ok(
-                paymentStatService.getDailyStats(startDate.atStartOfDay(), endDate.atTime(23, 59, 59))
+                paymentStatService.getDailyStats(startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX))
         );
     }
 }

--- a/src/main/java/com/nhnacademy/payment_server/docs/AdminPaymentSwagger.java
+++ b/src/main/java/com/nhnacademy/payment_server/docs/AdminPaymentSwagger.java
@@ -1,0 +1,35 @@
+package com.nhnacademy.payment_server.docs;
+
+import com.nhnacademy.payment_server.dto.response.DailySalesResponse;
+import com.nhnacademy.payment_server.dto.response.PaymentStatsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Admin Payment API", description = "관리자용 결제 통계 API")
+public interface AdminPaymentSwagger {
+
+    @Operation(
+            summary = "전체 매출 요약",
+            description = "총 매출 금액, 취소 금액, 결제/취소 건수 등을 조회합니다."
+    )
+    ResponseEntity<PaymentStatsResponse> getSummary();
+
+    @Operation(
+            summary = "일별 매출 차트 데이터",
+            description = "특정 기간의 일별 매출 합계를 조회합니다. 날짜를 지정하지 않으면 최근 7일 기준입니다."
+    )
+    ResponseEntity<List<DailySalesResponse>> getDailyStats(
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate startDate,
+
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate endDate
+    );
+}

--- a/src/main/java/com/nhnacademy/payment_server/dto/response/DailySalesResponse.java
+++ b/src/main/java/com/nhnacademy/payment_server/dto/response/DailySalesResponse.java
@@ -1,0 +1,15 @@
+package com.nhnacademy.payment_server.dto.response;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailySalesResponse {
+    private LocalDate date;
+    private Long dailyTotalAmount;
+    private Long dailyCount;
+}

--- a/src/main/java/com/nhnacademy/payment_server/dto/response/PaymentStatsResponse.java
+++ b/src/main/java/com/nhnacademy/payment_server/dto/response/PaymentStatsResponse.java
@@ -1,0 +1,19 @@
+package com.nhnacademy.payment_server.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentStatsResponse {
+    private Long totalSalesAmount;    // 총 매출액 (결제 완료 금액)
+    private Long totalCancelAmount;   // 총 환불액 (취소된 금액)
+    private Long netSalesAmount;      // 순 매출액 (총 매출 - 총 환불)
+    private Long totalTransactionCount; // 총 결제 건수
+    private Long successCount;        // 성공 건수
+    private Long cancelCount;         // 취소 건수
+}

--- a/src/main/java/com/nhnacademy/payment_server/exception/ErrorCode.java
+++ b/src/main/java/com/nhnacademy/payment_server/exception/ErrorCode.java
@@ -20,10 +20,11 @@ public enum ErrorCode {
     // 기능 없고 지원 예정
     NOT_IMPLEMENTED(HttpStatus.NOT_IMPLEMENTED, "P007", "추후 구현 예정인 결제 수단입니다."),
 
-    // 404 NOT_FOUND
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "P008", "존재하지 않는 결제 정보입니다."),
     METHOD_NOT_FOUND(HttpStatus.NOT_FOUND, "P009", "존재하지 않는 결제 수단입니다."),
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "P010", "존재하지 않는 주문 정보입니다."),
+
+    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "P011", "시작일은 종료일보다 이후일 수 없습니다."),
 
     // 500 INTERNAL_SERVER_ERROR
     TOSS_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "P500", "토스 페이먼츠 처리 중 오류가 발생했습니다."),

--- a/src/main/java/com/nhnacademy/payment_server/repository/PaymentRepository.java
+++ b/src/main/java/com/nhnacademy/payment_server/repository/PaymentRepository.java
@@ -1,7 +1,11 @@
 package com.nhnacademy.payment_server.repository;
 
+import com.nhnacademy.payment_server.dto.response.DailySalesResponse;
 import com.nhnacademy.payment_server.entity.Payment;
+import com.nhnacademy.payment_server.entity.PaymentStatus;
 import jakarta.persistence.LockModeType;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -9,11 +13,29 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
-    // 조회용
+    // 조회용 (추후 테스트용)
     Optional<Payment> findByPaymentKey(String PaymentKey);
 
     // 결제 취소용 비관적 락
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select p from Payment p where p.paymentKey = :paymentKey")
     Optional<Payment> findByPaymentKeyForUpdate(@Param("paymentKey") String paymentKey);
+
+    // 상태별 총 금액 합계 (예: DONE 상태의 총합 = 총 매출)
+    @Query("SELECT SUM(p.amount) FROM Payment p WHERE p.status = :status")
+    Optional<Long> sumAmountByStatus(@Param("status") PaymentStatus status);
+
+    // 상태별 건수
+    long countByStatus(PaymentStatus status);
+
+    // 특정 기간 일별 매출 통계 (JPQL + MySQL Date 함수)
+    // approvedAt을 기준으로 날짜별(Date) 그룹핑하여 합계와 건수를 구함
+    @Query("SELECT new com.nhnacademy.payment_server.dto.response.DailySalesResponse(" +
+            "CAST(p.approvedAt AS LocalDate), SUM(p.amount), COUNT(p)) " +
+            "FROM Payment p " +
+            "WHERE p.status = 'DONE' AND p.approvedAt BETWEEN :startDate AND :endDate " +
+            "GROUP BY CAST(p.approvedAt AS LocalDate) " +
+            "ORDER BY CAST(p.approvedAt AS LocalDate) ASC")
+    List<DailySalesResponse> findDailySalesBetween(@Param("startDate") LocalDateTime startDate,
+                                                   @Param("endDate") LocalDateTime endDate);
 }

--- a/src/main/java/com/nhnacademy/payment_server/service/PaymentStatService.java
+++ b/src/main/java/com/nhnacademy/payment_server/service/PaymentStatService.java
@@ -1,0 +1,41 @@
+package com.nhnacademy.payment_server.service;
+
+import com.nhnacademy.payment_server.dto.response.DailySalesResponse;
+import com.nhnacademy.payment_server.dto.response.PaymentStatsResponse;
+import com.nhnacademy.payment_server.entity.PaymentStatus;
+import com.nhnacademy.payment_server.repository.PaymentRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PaymentStatService {
+
+    private final PaymentRepository paymentRepository;
+
+    // 전체 요약 통계
+    public PaymentStatsResponse getTotalStats() {
+        Long sales = paymentRepository.sumAmountByStatus(PaymentStatus.DONE).orElse(0L);
+        Long cancels = paymentRepository.sumAmountByStatus(PaymentStatus.CANCELED).orElse(0L);
+        long successCount = paymentRepository.countByStatus(PaymentStatus.DONE);
+        long cancelCount = paymentRepository.countByStatus(PaymentStatus.CANCELED);
+
+        return PaymentStatsResponse.builder()
+                .totalSalesAmount(sales)
+                .totalCancelAmount(cancels)
+                .netSalesAmount(sales - cancels)
+                .successCount(successCount)
+                .cancelCount(cancelCount)
+                .totalTransactionCount(successCount + cancelCount)
+                .build();
+    }
+
+    // 기간별 일일 매출 통계
+    public List<DailySalesResponse> getDailyStats(LocalDateTime start, LocalDateTime end) {
+        return paymentRepository.findDailySalesBetween(start, end);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #13

## 📝작업 내용

> 관리자가 결제 통계를 확인할 수 있는 기능을 구현했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자용 결제 통계 API 추가: 전체 판매·취소·순이익 등 요약 통계 제공
  * 일일 판매 통계 조회 추가: 선택적 날짜 범위 필터로 일자별 매출액 및 거래 건수 확인 가능
* **버그 수정 / 개선**
  * 날짜 범위 입력에 대한 검증 추가 및 잘못된 범위 요청에 대한 명확한 오류 처리 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->